### PR TITLE
Refactor: Improve Firebase initialization failure guidance

### DIFF
--- a/js/websocket-client.js
+++ b/js/websocket-client.js
@@ -46,7 +46,7 @@ class OnlineBattleClient {
                 }
 
                 // Firebase不可用，回退到本地模拟
-                console.log('🔄 Firebase不可用，使用本地模拟模式');
+                console.warn('🔄 Firebase不可用，将使用本地模拟模式。请检查控制台中是否有更早的 Firebase 初始化错误信息 (例如，来自 firebase-config.js 或 firebase-battle.js)，这些错误可能指示具体原因 (如安全规则配置、网络问题或API密钥无效)。');
                 this.useFirebase = false;
 
                 // 加载Socket.IO库


### PR DESCRIPTION
When Firebase fails to initialize (often due to restrictive security rules or network issues), the `websocket-client.js` would fall back to a local simulation mode, logging a generic "Firebase不可用" message.

This commit updates the console message in `js/websocket-client.js` to be a more informative warning. It now explicitly advises you to check the browser console for earlier, more detailed error messages that might have been logged by `firebase-config.js` or `firebase-battle.js`. These earlier messages often contain specific reasons for the failure, such as permission denied errors from security rules or network connectivity problems.

This change aims to make debugging Firebase setup issues more straightforward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced console warning message when Firebase is unavailable, providing clearer guidance on troubleshooting potential issues such as security rules, network problems, or invalid API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->