### PR TITLE
Increase AI opponent response delay

### DIFF
--- a/js/battle-manager.js
+++ b/js/battle-manager.js
@@ -714,8 +714,8 @@ class BattleManager {
      * 模拟对手响应（本地同步机制）
      */
     simulateOpponentResponse(myActionData) {
-        // 模拟对手的响应时间（竞速模式：2-8秒）
-        const responseDelay = 2000 + Math.random() * 6000;
+        // 模拟对手的响应时间（竞速模式：5-12秒）
+        const responseDelay = 5000 + Math.random() * 7000;
 
         setTimeout(() => {
             // 模拟对手答题结果（55%正确率，让游戏更有挑战性）
@@ -737,7 +737,7 @@ class BattleManager {
         }, responseDelay);
 
         // 模拟对手也会继续答题（竞速模式）
-        const nextQuestionDelay = 3000 + Math.random() * 5000;
+        const nextQuestionDelay = 6000 + Math.random() * 9000;
         setTimeout(() => {
             if (this.gameState.isActive) {
                 // 模拟对手答下一道题


### PR DESCRIPTION
This change modifies the AI opponent's response delay in `js/battle-manager.js` to make it more human-like.

The `responseDelay` has been changed from a range of 2-8 seconds to 5-12 seconds. The `nextQuestionDelay` has been changed from a range of 3-8 seconds to 6-15 seconds.

These adjustments aim to provide you with more time to process questions, especially in audio-based challenges, and to create a more balanced gameplay experience.