### PR TITLE
Fix: Correct Firebase path for player status updates in matching

### DIFF
--- a/js/firebase-battle.js
+++ b/js/firebase-battle.js
@@ -345,8 +345,8 @@ class FirebaseBattleManager {
 
                         // 更新双方在匹配池中的状态为 'matched'
                         const updates = {};
-                        updates[`matchingPool/${currentUserGrade}/${currentUserId}/status`] = 'matched';
-                        updates[`matchingPool/${currentUserGrade}/${opponentId}/status`] = 'matched';
+updates[`matching/${currentUserGrade}/${currentUserId}/status`] = 'matched';
+updates[`matching/${currentUserGrade}/${opponentId}/status`] = 'matched';
                         this.database.ref().update(updates)
                             .then(() => console.log(`🎉 成功更新匹配池中 ${currentUserId} 和 ${opponentId} 的状态为 'matched'`))
                             .catch(err => console.error('🔥 更新匹配池状态失败:', err));


### PR DESCRIPTION
The previous code was attempting to update player statuses (from 'waiting' to 'matched') under an incorrect Firebase path (`matchingPool/...`) instead of the correct path (`matching/...`).

This error prevented player statuses from being properly updated after a match was made. As a result, matched players would still appear as 'waiting' in the matching pool, causing subsequent matching attempts for that grade to fail to find new opponents or behave unpredictably.

This commit corrects the paths in `js/firebase-battle.js` within the `onMatchingPoolChange` function to ensure that player statuses are updated in the correct location in the Firebase Realtime Database. This should resolve the issue where players on different devices could not find each other when matching for the same grade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of player matching status updates in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->