### PR TITLE
Fix: Prevent TypeError in battle_level1.html

### DIFF
--- a/screens/battle_level1.html
+++ b/screens/battle_level1.html
@@ -474,8 +474,12 @@
                 const player = gameData.player;
                 const opponent = gameData.opponent;
 
-                myNicknameEl.textContent = player.nickname || '我';
-                opponentNicknameEl.textContent = opponent.nickname || '对手';
+                if (myNicknameEl) {
+                    myNicknameEl.textContent = player.nickname || '我';
+                }
+                if (opponentNicknameEl) {
+                    opponentNicknameEl.textContent = opponent.nickname || '对手';
+                }
 
                 // 优先使用Firebase传递的角色信息
                 let myRole = null;


### PR DESCRIPTION
Added null checks for myNicknameEl and opponentNicknameEl in the initializeBattleInfo function. This prevents a TypeError that occurred when these elements were not found in the DOM, which was causing problems with loading content during AI battles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability in double battle mode by preventing errors when displaying player and opponent nicknames if display elements are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->