### PR TITLE
Fix: Adjust matching wait time and AI answer interval

### DIFF
--- a/js/battle-manager.js
+++ b/js/battle-manager.js
@@ -737,7 +737,7 @@ class BattleManager {
         }, responseDelay);
 
         // 模拟对手也会继续答题（竞速模式）
-        const nextQuestionDelay = 3000 + Math.random() * 5000;
+        const nextQuestionDelay = 10000 + Math.random() * 5000;
         setTimeout(() => {
             if (this.gameState.isActive) {
                 // 模拟对手答下一道题

--- a/screens/matching.html
+++ b/screens/matching.html
@@ -171,7 +171,7 @@
                 }
 
                 // 模拟匹配成功 (备用机制) - only if not in error state
-                if (waitTime >= 15 && Math.random() < 0.1 && matchingStatusElement.style.color !== 'rgb(255, 204, 204)') {
+                if (waitTime >= 20 && Math.random() < 0.1 && matchingStatusElement.style.color !== 'rgb(255, 204, 204)') {
                     simulateMatchFound();
                 }
             }, 1000);


### PR DESCRIPTION
Addresses two timing-related issues:

1. Matching wait time:
   - The simulated match fallback in `screens/matching.html` was triggered if the wait time exceeded 15 seconds.
   - This has been changed to 20 seconds to meet your specified requirement.

2. AI answer interval:
   - The AI's answering interval was inconsistent. While the initial response delay was 10-15 seconds, subsequent simulated answers could occur much faster (3-8 seconds).
   - I modified `js/battle-manager.js` in the `simulateOpponentResponse` function to ensure that the delay for scheduling subsequent AI answers (`simulateOpponentNextAnswer`) is also 10-15 seconds.
   - The recursive delay within `simulateOpponentNextAnswer` was already correctly set at 10-15 seconds.
   - This change ensures a consistent 10-15 second answering interval for the AI.