### PR TITLE
Fix: Correct AI provision time and standardize AI answer intervals

### DIFF
--- a/js/websocket-client.js
+++ b/js/websocket-client.js
@@ -372,7 +372,7 @@ class OnlineBattleClient {
                             console.log('🏁 模拟对手关卡结束响应');
                             // 不需要特别响应，让游戏自然结束
                         }
-                    }, 800 + Math.random() * 1500); // 0.8-2.3秒后响应，更加真实
+                    }, 10000 + Math.random() * 5000); // 0.8-2.3秒后响应，更加真实
                 } else {
                     // 真人对战模式：不进行模拟响应
                     console.log('👥 真人对战模式，不模拟对手响应:', data);
@@ -526,7 +526,7 @@ class OnlineBattleClient {
      */
     startMatchingPolling(playerData) {
         let attempts = 0;
-        const maxAttempts = 15; // 减少到15秒，更快提供AI对手
+        const maxAttempts = 20; // 减少到15秒，更快提供AI对手
 
         console.log('开始匹配轮询，将在', maxAttempts, '秒后提供AI对手');
 


### PR DESCRIPTION
This commit addresses persistent issues with AI opponent timing:

1. AI Opponent Provision Time:
   - I modified `js/websocket-client.js` in the `startMatchingPolling` function.
   - I changed `maxAttempts` from 15 to 20, so the system now waits 20 seconds for a real player before providing an AI opponent.
   - The associated console log will reflect this updated time.

2. AI Answer Interval:
   - I corrected the AI answer speed in the mock response logic within `js/websocket-client.js`. In the `handleMockResponse` function, I changed the AI's response delay from 0.8-2.3 seconds to 10-15 seconds.
   - I verified that the AI simulation logic in `js/battle-manager.js` (functions `simulateOpponentResponse` and `simulateOpponentNextAnswer`) also correctly uses a 10-15 second delay for AI responses.

These changes ensure that AI opponent provision during matching and AI answer speeds during gameplay are consistent with the desired 20-second and 10-15 second intervals, respectively, across different fallback mechanisms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Increased the response delay for the AI opponent, resulting in a longer wait time before the AI responds during gameplay.
  - Extended the waiting period for finding a real opponent before switching to an AI opponent, allowing more time for matchmaking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->